### PR TITLE
Check for tokens length before accessing

### DIFF
--- a/index.js
+++ b/index.js
@@ -72,12 +72,14 @@ export default function parseStylesheet(source) {
 			tokens.length = 0;
 		} else if (stream.eat(RULE_START)) {
 			flush();
-			child = tokens[0].type === 'at-keyword'
+			if (tokens.length > 0) {
+				child = tokens[0].type === 'at-keyword'
 				? createAtRule(stream, tokens, new Token(stream, 'body-start'))
 				: createRule(stream, tokens, new Token(stream, 'body-start'));
-			ctx.add(child);
-			ctx = child;
-			tokens.length = 0;
+				ctx.add(child);
+				ctx = child;
+				tokens.length = 0;
+			}
 		} else if (stream.eat(RULE_END)) {
 			flush();
 


### PR DESCRIPTION
The css parser fails to parse the below less example from http://lesscss.org/features/#loops-feature

```
.generate-columns(4);

.generate-columns(@n, @i: 1) when (@i =< @n) {
  .column-@{i} {
    width: (@i * 100% / @n);
  }
  .generate-columns(@n, (@i + 1));
}
```

This PR will fix the parsing issue

cc @sergeche 